### PR TITLE
Ajout interface FXML

### DIFF
--- a/src/main/resources/fr/val/chaudiere/ui/checklist.fxml
+++ b/src/main/resources/fr/val/chaudiere/ui/checklist.fxml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.layout.BorderPane?>
+<?import javafx.scene.layout.VBox?>
+<BorderPane xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml" fx:controller="fr.val.chaudiere.ui.controller.ChecklistController">
+    <center>
+        <VBox fx:id="root" spacing="8" />
+    </center>
+    <bottom>
+        <Button text="Enregistrer" onAction="#onSave" BorderPane.alignment="CENTER" />
+    </bottom>
+</BorderPane>


### PR DESCRIPTION
## Résumé
- ajout du fichier `checklist.fxml` qui définit l’interface JavaFX

## Testing
- `mvn -q package` *(échoue : `mvn` absent)*

------
https://chatgpt.com/codex/tasks/task_e_683b81e99254832e938dc724c81696fa