### PR TITLE
Correction chargement FXML

### DIFF
--- a/src/main/java/fr/val/chaudiere/ui/MainApp.java
+++ b/src/main/java/fr/val/chaudiere/ui/MainApp.java
@@ -11,7 +11,8 @@ import javafx.stage.Stage;
 public class MainApp extends Application {
     @Override
     public void start(Stage stage) throws Exception {
-        FXMLLoader loader = new FXMLLoader(getClass().getResource("checklist.fxml"));
+        // Chargement via un chemin absolu pour garantir la présence du FXML
+        FXMLLoader loader = new FXMLLoader(MainApp.class.getResource("/fr/val/chaudiere/ui/checklist.fxml"));
         Scene scene = new Scene(loader.load());
         stage.setTitle("Contrôle chaudière");
         stage.setScene(scene);

--- a/src/main/resources/fr/val/chaudiere/ui/checklist.fxml
+++ b/src/main/resources/fr/val/chaudiere/ui/checklist.fxml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.layout.BorderPane?>
+<?import javafx.scene.layout.VBox?>
+<BorderPane xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml" fx:controller="fr.val.chaudiere.ui.controller.ChecklistController">
+    <center>
+        <VBox fx:id="root" spacing="8" />
+    </center>
+    <bottom>
+        <Button text="Enregistrer" onAction="#onSave" BorderPane.alignment="CENTER" />
+    </bottom>
+</BorderPane>


### PR DESCRIPTION
## Résumé
- correction du chemin de `checklist.fxml` pour que le fichier soit bien trouvé

## Testing
- `mvn -q package` *(échoue : `mvn` absent)*


------
https://chatgpt.com/codex/tasks/task_e_683b81e99254832e938dc724c81696fa